### PR TITLE
Temporarily add profiling to WASM code using new BasicProfiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7054,9 +7054,12 @@ name = "sp-io"
 version = "2.0.0"
 dependencies = [
  "hash-db",
+ "lazy_static",
  "libsecp256k1",
  "log 0.4.8",
  "parity-scale-codec",
+ "parking_lot 0.10.0",
+ "sc-tracing",
  "sp-core",
  "sp-externalities",
  "sp-runtime-interface",

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -273,8 +273,11 @@ where
 		encoded_len: usize,
 		to_note: Option<Vec<u8>>,
 	) -> ApplyExtrinsicResult {
+		let span_id = sp_io::profiling::register_span(module_path!(), "apply_extrinsic_with_len");
 		// Verify that the signature is good.
+		let span_id2 = sp_io::profiling::register_span(module_path!(), "uxt.check(&Default::default())?");
 		let xt = uxt.check(&Default::default())?;
+		sp_io::profiling::exit_span(span_id2);
 
 		// We don't need to make sure to `note_extrinsic` only after we know it's going to be
 		// executed to prevent it from leaking in storage since at this point, it will either
@@ -290,7 +293,7 @@ where
 		let r = Applyable::apply::<UnsignedValidator>(xt, dispatch_info, encoded_len)?;
 
 		<frame_system::Module<System>>::note_applied_extrinsic(&r, encoded_len as u32, dispatch_info);
-
+		sp_io::profiling::exit_span(span_id);
 		Ok(r)
 	}
 

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = { version = "0.2.4", default-features = false, optional = true }
 sp-state-machine = { version = "0.8", optional = true, path = "../../primitives/state-machine" }
 bitmask = { version = "0.5.0", default-features = false }
 impl-trait-for-tuples = "0.1.3"
-tracing = { version = "0.1.10", optional = true }
+tracing = { version = "0.1.12", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -860,13 +860,17 @@ macro_rules! decl_module {
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_initialize(_block_number_not_used: $trait_instance::BlockNumber) {
-				use $crate::sp_std::if_std;
-				if_std! {
-					use $crate::tracing;
-					let span = tracing::span!(tracing::Level::DEBUG, "on_initialize");
-					let _enter = span.enter();
-				}
-				{ $( $impl )* }
+//				use $crate::sp_std::if_std;
+//				if_std! {
+//					use $crate::tracing;
+//					let span = tracing::span!(tracing::Level::DEBUG, "on_initialize");
+//					let _enter = span.enter();
+//				}
+				use $crate::sp_io;
+				let span_id = sp_io::profiling::register_span(module_path!(), "on_initialize");
+				{ $( $impl )* };
+				sp_io::profiling::exit_span(span_id);
+//				{ $( $impl )* }
 			}
 		}
 	};
@@ -882,13 +886,17 @@ macro_rules! decl_module {
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_initialize($param: $param_ty) {
-				use $crate::sp_std::if_std;
-				if_std! {
-					use $crate::tracing;
-					let span = tracing::span!(tracing::Level::DEBUG, "on_initialize");
-					let _enter = span.enter();
-				}
-				{ $( $impl )* }
+//				use $crate::sp_std::if_std;
+//				if_std! {
+//					use $crate::tracing;
+//					let span = tracing::span!(tracing::Level::DEBUG, "on_initialize");
+//					let _enter = span.enter();
+//				}
+				use $crate::sp_io;
+				let span_id = sp_io::profiling::register_span(module_path!(), "on_initialize");
+				{ $( $impl )* };
+				sp_io::profiling::exit_span(span_id);
+//				{ $( $impl )* }
 			}
 		}
 	};
@@ -914,13 +922,17 @@ macro_rules! decl_module {
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_finalize(_block_number_not_used: $trait_instance::BlockNumber) {
-				use $crate::sp_std::if_std;
-				if_std! {
-					use $crate::tracing;
-					let span = tracing::span!(tracing::Level::DEBUG, "on_finalize");
-					let _enter = span.enter();
-				}
-				{ $( $impl )* }
+//				use $crate::sp_std::if_std;
+//				if_std! {
+//					use $crate::tracing;
+//					let span = tracing::span!(tracing::Level::DEBUG, "on_finalize");
+//					let _enter = span.enter();
+//				}
+				use $crate::sp_io;
+				let span_id = sp_io::profiling::register_span(module_path!(), "on_finalize");
+				{ $( $impl )* };
+				sp_io::profiling::exit_span(span_id);
+//				{ $( $impl )* }
 			}
 		}
 	};
@@ -936,13 +948,17 @@ macro_rules! decl_module {
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_finalize($param: $param_ty) {
-				use $crate::sp_std::if_std;
-				if_std! {
-					use $crate::tracing;
-					let span = tracing::span!(tracing::Level::DEBUG, "on_finalize");
-					let _enter = span.enter();
-				}
-				{ $( $impl )* }
+//				use $crate::sp_std::if_std;
+//				if_std! {
+//					use $crate::tracing;
+//					let span = tracing::span!(tracing::Level::DEBUG, "on_finalize");
+//					let _enter = span.enter();
+//				}
+				use $crate::sp_io;
+				let span_id = sp_io::profiling::register_span(module_path!(), "on_finalize");
+				{ $( $impl )* };
+				sp_io::profiling::exit_span(span_id);
+//				{ $( $impl )* }
 			}
 		}
 	};
@@ -1039,14 +1055,17 @@ macro_rules! decl_module {
 		$vis fn $name(
 			$origin: $origin_ty $(, $param: $param_ty )*
 		) -> $crate::dispatch::DispatchResult {
-			$crate::sp_std::if_std! {
-				use $crate::tracing;
-				let span = tracing::span!(tracing::Level::DEBUG, stringify!($name));
-				let _enter = span.enter();
-			}
+//			$crate::sp_std::if_std! {
+//				use $crate::tracing;
+//				let span = tracing::span!(tracing::Level::DEBUG, stringify!($name));
+//				let _enter = span.enter();
+//			}
 			{
-				{ $( $impl )* }
-				Ok(())
+				use $crate::sp_io;
+				let span_id = sp_io::profiling::register_span(module_path!(), stringify!($name));
+				let result: $crate::dispatch::DispatchResult = (move || { { $( $impl )* } Ok(()) })();
+				sp_io::profiling::exit_span(span_id);
+				result
 			}
 		}
 	};
@@ -1064,13 +1083,17 @@ macro_rules! decl_module {
 	) => {
 		$(#[doc = $doc_attr])*
 		$vis fn $name($origin: $origin_ty $(, $param: $param_ty )* ) -> $result {
-			use $crate::sp_std::if_std;
-			if_std! {
-				use $crate::tracing;
-				let span = tracing::span!(tracing::Level::DEBUG, stringify!($name));
-				let _enter = span.enter();
-			}
-			{ $( $impl )* }
+//			use $crate::sp_std::if_std;
+//			if_std! {
+//				use $crate::tracing;
+//				let span = tracing::span!(tracing::Level::DEBUG, stringify!($name));
+//				let _enter = span.enter();
+//			}
+			use $crate::sp_io;
+			let span_id = sp_io::profiling::register_span(module_path!(), stringify!($name));
+			let result: $result = (move || { $( $impl )* })();
+			sp_io::profiling::exit_span(span_id);
+			result
 		}
 	};
 

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -26,6 +26,8 @@ extern crate bitmask;
 #[cfg(feature = "std")]
 pub extern crate tracing;
 
+pub use sp_io;
+
 #[cfg(feature = "std")]
 pub use serde;
 #[doc(hidden)]

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -834,7 +834,9 @@ impl<T: Trait> Module<T> {
 
 	/// Increment a particular account's nonce by 1.
 	pub fn inc_account_nonce(who: &T::AccountId) {
+		let span_id = sp_io::profiling::register_span(module_path!(), "inc_account_nonce");
 		<AccountNonce<T>>::insert(who, Self::account_nonce(who) + T::Index::one());
+		sp_io::profiling::exit_span(span_id);
 	}
 
 	/// Note what the extrinsic data of the current extrinsic index is. If this
@@ -1052,7 +1054,9 @@ impl<T: Trait> SignedExtension for CheckNonce<T> {
 		_info: Self::DispatchInfo,
 		_len: usize,
 	) -> Result<(), TransactionValidityError> {
+		let span_id = sp_io::profiling::register_span(module_path!(), "<AccountNonce<T>>::get");
 		let expected = <AccountNonce<T>>::get(who);
+		sp_io::profiling::exit_span(span_id);
 		if self.0 != expected {
 			return Err(
 				if self.0 < expected {
@@ -1063,7 +1067,9 @@ impl<T: Trait> SignedExtension for CheckNonce<T> {
 			)
 		}
 
+		let span_id = sp_io::profiling::register_span(module_path!(), "<AccountNonce<T>>::insert");
 		<AccountNonce<T>>::insert(who, expected + T::Index::one());
+		sp_io::profiling::exit_span(span_id);
 		Ok(())
 	}
 

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -12,6 +12,7 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../../primit
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-features = false, path = "./rpc/runtime-api" }
+sp-io ={ path = "../../primitives/io", default-features = false }
 
 [dev-dependencies]
 sp-io = { version = "2.0.0", path = "../../primitives/io" }
@@ -23,6 +24,7 @@ default = ["std"]
 std = [
 	"codec/std",
 	"sp-std/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -17,6 +17,9 @@ sp-runtime-interface = { version = "2.0.0", default-features = false, path = "..
 sp-trie = { version = "2.0.0", optional = true, path = "../../primitives/trie" }
 sp-externalities = { version = "0.8.0", optional = true, path = "../externalities" }
 log = { version = "0.4.8", optional = true }
+sc-tracing = { version = "2.0.0", optional = true, path = "../../client/tracing" }
+parking_lot = { version = "0.10.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 
 [features]
 default = ["std"]
@@ -32,6 +35,9 @@ std = [
 	"sp-externalities",
 	"sp-wasm-interface/std",
 	"log",
+	"sc-tracing",
+	"parking_lot",
+	"lazy_static"
 ]
 
 # These two features are used for `no_std` builds for the environments which already provides


### PR DESCRIPTION
temporarily remove standard tracing from runtime. TODO add line numbers.
